### PR TITLE
PLANTE-1239: Utvidet feilhåndtering, og skal ikke legge sertifikat på feilkø dersom lagring til gcp feiler

### DIFF
--- a/src/main/kotlin/no/mattilsynet/ephyto/api/clients/EphytoClient.kt
+++ b/src/main/kotlin/no/mattilsynet/ephyto/api/clients/EphytoClient.kt
@@ -24,10 +24,10 @@ abstract class EphytoClient {
     fun acknowledgeEnvelope(valideringsresultat: Valideringsresultat) {
         when (valideringsresultat.validatedOk) {
             true -> acknowledgeSuccessfulEnvelope(valideringsresultat)
-            else -> acknowledgeFailedEnvelope(valideringsresultat)
+            false -> acknowledgeFailedEnvelope(valideringsresultat)
+            else -> Unit
         }
     }
-
 
     fun getImportEnvelopeHeaders(): List<EnvelopeHeader>? =
         runCatching {

--- a/src/main/kotlin/no/mattilsynet/ephyto/api/domain/Valideringsresultat.kt
+++ b/src/main/kotlin/no/mattilsynet/ephyto/api/domain/Valideringsresultat.kt
@@ -8,5 +8,5 @@ data class Valideringsresultat(
     val errorMessage: String?,
     val hubLeveringNummer: String,
     val hubTrackingInfo: HUBTrackingInfo,
-    val validatedOk: Boolean,
+    var validatedOk: Boolean?,
 )

--- a/src/main/kotlin/no/mattilsynet/ephyto/api/services/EphytoService.kt
+++ b/src/main/kotlin/no/mattilsynet/ephyto/api/services/EphytoService.kt
@@ -35,10 +35,10 @@ class EphytoService(
     fun hentOgHaandterNyEnvelope(envelopeHeader: EnvelopeHeader) {
         runCatching {
             ephytoClient.getSingleImportEnvelopeOrNull(envelopeHeader.hubDeliveryNumber).also { envelope ->
-                val valideringsresultat = ephytoValideringService
+                var valideringsresultat = ephytoValideringService
                     .getValidationResultForEnvelope(envelope, envelopeHeader.hubDeliveryNumber)
                 if (envelope != null) {
-                    envelopeService.haandterNyEnvelope(envelope, valideringsresultat.hubTrackingInfo)
+                    valideringsresultat = envelopeService.haandterNyEnvelope(envelope, valideringsresultat)
                 } else {
                     logger.error("Kunne ikke hente envelope med hubLeveringNummer ${envelopeHeader.hubDeliveryNumber}")
                 }

--- a/src/main/kotlin/no/mattilsynet/ephyto/api/services/GcpStorageService.kt
+++ b/src/main/kotlin/no/mattilsynet/ephyto/api/services/GcpStorageService.kt
@@ -1,6 +1,5 @@
 package no.mattilsynet.ephyto.api.services
 
-import com.google.cloud.storage.Blob
 import com.google.cloud.storage.Bucket
 import com.google.cloud.storage.Storage
 import com.google.cloud.storage.StorageException
@@ -27,7 +26,7 @@ class GcpStorageService(
         contentBytes: ByteArray,
         dataUrl: String,
         hubLeveringNummer: String,
-    ): Blob? =
+    ) =
         getBucket(bucketName)?.let { bucket ->
             try {
                 bucket.create(
@@ -41,8 +40,8 @@ class GcpStorageService(
                 }
             } catch (e: StorageException) {
                 logger.error("Filen for $hubLeveringNummer kunne ikke skrives til bucket: $bucketName. " +
-                        "Exception: ${e.message}")
-                null
+                        "dataUrl: $dataUrl, lengde på contentBytes: ${contentBytes.size}" +
+                        "Exception: ${e.message}", e)
             }
         }
     

--- a/src/test/kotlin/no/mattilsynet/ephyto/api/services/EphytoServiceTest.kt
+++ b/src/test/kotlin/no/mattilsynet/ephyto/api/services/EphytoServiceTest.kt
@@ -122,14 +122,21 @@ internal class EphytoServiceTest {
         // Given:
         val envelopeMock = createEnvelopeMock(content = xmlSertifikatContent)
         doReturn(envelopeMock).`when`(ephytoClient).getSingleImportEnvelopeOrNull(any())
-        doReturn(createValideringsresultatMock(envelopeMock))
+        val valideringsresultatMock = createValideringsresultatMock(envelopeMock)
+        doReturn(valideringsresultatMock)
             .`when`(ephytoValideringService).getValidationResultForEnvelope(any(), any())
+
+        doReturn(valideringsresultatMock).`when`(envelopeService)
+            .haandterNyEnvelope(envelopeMock, valideringsresultatMock)
 
         // When:
         ephytoService.hentOgHaandterNyEnvelope(createEnvelopeHeaderMock())
 
         // Then:
-        verify(envelopeService).haandterNyEnvelope(envelope = envelopeMock, hubTrackingInfo = HUBTrackingInfo.DELIVERED)
+        verify(envelopeService).haandterNyEnvelope(
+            envelope = envelopeMock,
+            valideringsresultat = valideringsresultatMock,
+        )
         verify(ephytoClient, times(1)).acknowledgeEnvelope(any())
     }
 
@@ -139,12 +146,15 @@ internal class EphytoServiceTest {
         val envelopeMock = createEnvelopeMock(content = null)
         doReturn(envelopeMock).`when`(ephytoClient).getSingleImportEnvelopeOrNull(any())
         val envelopeHeader = createEnvelopeHeaderMock()
-        val mockValideringsresultat = createValideringsresultatMock(
+        val valideringsresultatMock = createValideringsresultatMock(
             envelopeMock = envelopeMock,
             hubTrackingInfo = HUBTrackingInfo.DELIVERED_NOT_READABLE,
         )
-        doReturn(mockValideringsresultat).`when`(ephytoValideringService)
+        doReturn(valideringsresultatMock).`when`(ephytoValideringService)
             .getValidationResultForEnvelope(envelopeMock, envelopeMock.hubDeliveryNumber)
+
+        doReturn(valideringsresultatMock).`when`(envelopeService)
+            .haandterNyEnvelope(envelopeMock, valideringsresultatMock)
 
         // When:
         ephytoService.hentOgHaandterNyEnvelope(envelopeHeader)
@@ -152,10 +162,10 @@ internal class EphytoServiceTest {
         // Then:
         verify(envelopeService).haandterNyEnvelope(
             envelope = envelopeMock,
-            hubTrackingInfo = HUBTrackingInfo.DELIVERED_NOT_READABLE,
+            valideringsresultat = valideringsresultatMock,
         )
         verify(ephytoClient, times(1))
-            .acknowledgeEnvelope(mockValideringsresultat)
+            .acknowledgeEnvelope(valideringsresultatMock)
     }
 
     @Test
@@ -165,9 +175,12 @@ internal class EphytoServiceTest {
         val envelopeMock = createEnvelopeMock(content = xmlSertifikatContent)
 
         doReturn(envelopeMock).`when`(ephytoClient).getSingleImportEnvelopeOrNull(any())
-        val mockValideringsresultat = createValideringsresultatMock(envelopeMock)
-        doReturn(mockValideringsresultat).`when`(ephytoValideringService)
+        val valideringsresultatMock = createValideringsresultatMock(envelopeMock)
+        doReturn(valideringsresultatMock).`when`(ephytoValideringService)
             .getValidationResultForEnvelope(envelopeMock, envelopeMock.hubDeliveryNumber)
+
+        doReturn(valideringsresultatMock).`when`(envelopeService)
+            .haandterNyEnvelope(envelopeMock, valideringsresultatMock)
 
         // When:
         ephytoService.hentOgHaandterNyEnvelope(envelopeHeader)
@@ -175,10 +188,10 @@ internal class EphytoServiceTest {
         // Then:
         verify(envelopeService).haandterNyEnvelope(
             envelope = envelopeMock,
-            hubTrackingInfo = mockValideringsresultat.hubTrackingInfo,
+            valideringsresultat = valideringsresultatMock,
         )
         verify(ephytoClient, times(1))
-            .acknowledgeEnvelope(valideringsresultat = mockValideringsresultat)
+            .acknowledgeEnvelope(valideringsresultat = valideringsresultatMock)
     }
 
     @Test

--- a/src/test/kotlin/no/mattilsynet/ephyto/api/services/EphytoValideringServiceTest.kt
+++ b/src/test/kotlin/no/mattilsynet/ephyto/api/services/EphytoValideringServiceTest.kt
@@ -60,7 +60,7 @@ internal class EphytoValideringServiceTest {
             assertEquals("Could not read the envelope from the hub", errorMessage)
             assertEquals("hubDeliveryNumber", hubLeveringNummer)
             assertEquals(HUBTrackingInfo.ENVELOPE_NOT_EXISTS, hubTrackingInfo)
-            assertFalse(validatedOk)
+            assertFalse(validatedOk == true)
         }
     }
 
@@ -82,7 +82,7 @@ internal class EphytoValideringServiceTest {
             assertEquals("The content of the envelope from the hub is empty", errorMessage)
             assertEquals(envelopeMock.hubDeliveryNumber, hubLeveringNummer)
             assertEquals(HUBTrackingInfo.DELIVERED_NOT_READABLE, hubTrackingInfo)
-            assertFalse(validatedOk)
+            assertFalse(validatedOk == true)
         }
     }
 }

--- a/src/test/kotlin/no/mattilsynet/ephyto/api/validators/EphytoEnvelopeValidatorTest.kt
+++ b/src/test/kotlin/no/mattilsynet/ephyto/api/validators/EphytoEnvelopeValidatorTest.kt
@@ -50,7 +50,7 @@ class EphytoEnvelopeValidatorTest {
         with(valideringsresultat) {
             assertEquals(mockEnvelope, envelope)
             assertEquals(null, errorMessage)
-            assertTrue(validatedOk)
+            assertTrue(validatedOk == true)
             assertEquals(mockEnvelope.hubDeliveryNumber, hubLeveringNummer)
             assertEquals(HUBTrackingInfo.DELIVERED, hubTrackingInfo)
         }
@@ -73,7 +73,7 @@ class EphytoEnvelopeValidatorTest {
         with(valideringsresultat) {
             assertEquals(mockEnvelope, envelope)
             assertEquals(null, errorMessage)
-            assertTrue(validatedOk)
+            assertTrue(validatedOk == true)
             assertEquals(mockEnvelope.hubDeliveryNumber, hubLeveringNummer)
             assertEquals(HUBTrackingInfo.DELIVERED, hubTrackingInfo)
         }
@@ -92,7 +92,7 @@ class EphytoEnvelopeValidatorTest {
         with(valideringsresultat) {
             assertEquals(mockEnvelope, envelope)
             assertEquals("The XML content in the envelope is not readable", errorMessage)
-            assertFalse(validatedOk)
+            assertFalse(validatedOk == true)
             assertEquals(mockEnvelope.hubDeliveryNumber, hubLeveringNummer)
             assertEquals(HUBTrackingInfo.DELIVERED_NOT_READABLE, hubTrackingInfo)
         }
@@ -119,7 +119,7 @@ class EphytoEnvelopeValidatorTest {
         with(valideringsresultat) {
             assertEquals(mockEnvelope, envelope)
             assertTrue(valideringsresultat.errorMessage!!.contains("SEVERE"))
-            assertTrue(validatedOk)
+            assertTrue(validatedOk == true)
             assertEquals(mockEnvelope.hubDeliveryNumber, hubLeveringNummer)
             assertEquals(HUBTrackingInfo.DELIVERED_WITH_WARNINGS, hubTrackingInfo)
         }


### PR DESCRIPTION
Et nederlandsk sertifikat feilet ved lagring til gcp. Feilmeldingen ga lite informasjon, og er nå utvidet til å ta med flere av innparametrene for å se om det er noe galt der, og stacktracen er lagt ved.

Det er også gjort endringer sånn at vi ikke poster til feilkø dersom lagringen feiler. Vi sender heller ikke acknowledgement til hub'en, så sertifikatet vil leses inn igjen neste gang, og hvis det var en midlertidig feil ved lagringen, så vil det gå bra ved neste innlesing.